### PR TITLE
Large update: calculate beta self-consistently rather than iteratively

### DIFF
--- a/input_file
+++ b/input_file
@@ -39,7 +39,10 @@ id_peaks        1         # Identify peaks and save their locations (on/off)
 calc_ap_flux    1         # Calculate the enclosed flux for each peak and aperture size (on/off)
 generate_plot   1         # Generate output plots and save to PostScript files (on/off)
 get_distances   1         # Calculate distances between all peak pairs (on/off)
-calc_fit        1         # Iteratively: Monte-Carlo sample peaks, get observed tuning fork, fit KL14 principle model (on/off)
+calc_obs        1         # Monte-Carlo sample peaks, get observed tuning fork (on/off)
+calc_fit        1         # Fit KL14 principle model (on/off)
+derive_phys     1         # Calculate derived physical quantities (on/off)
+write_output    1         # Write results to output files (on/off)
 cleanup         2         # [0] Keep auxiliary files to allow any of the above flags to be set to 0 for future runs; [1, DEFAULT] Delete auxiliary files after confirmation prompt; [2] WARNING: Automatically delete auxiliary files
 autoexit        0         # Exit IDL automatically upon successful run completion (on/off)
 # FLAGS 2 (use ancillary files)
@@ -103,13 +106,10 @@ tstariso_errmax 0.        # Upward standard error of the reference time-scale in
 tgasmini        0.1       # Minimum value of tgas considered during fitting process in Myr
 tgasmaxi        5000.     # Maximum value of tgas considered during fitting process in Myr
 tovermini       0.01      # Minimum value of tover considered during fitting process in Myr
-fstarover       0.1       # Fraction of stellar phase initially assumed to be associated with gas emission
-fgasover        0.1       # Fraction of gas phase initially assumed to be associated with stellar emission
 # INPUT PARAMETERS 5 (fitting)
-nit             10        # Maximum number of iterations carried out by fitting process
 nmc             100       # Number of Monte-Carlo peak drawing experiments to be executed and averaged over during fitting process
-ndepth          5         # Maximum number of free parameter array refinement loops for obtaining best-fitting value
-ntry            81        # Size of each free parameter array to obtain the best-fitting value
+ndepth          4         # Maximum number of free parameter array refinement loops for obtaining best-fitting value
+ntry            101       # Size of each free parameter array to obtain the best-fitting value
 nphysmc         10000     # Number of Monte-Carlo experiments for error propagation of derived physical quantities
 # INPUT PARAMETERS 6 (conversions and constants to calculate derived quantities)
 convstar       -3.69206   # Log of multiplication factor to convert the pixel value in starfile to a SFR in Msun/yr (if maptypes=1 or maptypes=3) or to a gas mass in Msun (if maptypes=2)


### PR DESCRIPTION
- beta_star(fstarover) with fstarover=tover/tstar
- beta_gas(fgasover) with fgasover=tover/tgas
- both beta_star(fstarover) and beta_gas(fgasover) are now used in fitKL14 (variable beta)
- iteration to converge on beta has been removed
- assigned beta_star and beta_gas to derived quantities
- created beta_star and beta_gas error propagation
- created beta_star and beta_gas output files (including errors)
- reorganised tuningfork.pro structure
- updated input_file

Addresses #45, #64 and #80.

All users please verify that the above issues have been satisfactorily addressed.
