### PR TITLE
Revised error check for aperture size < pixel size

### DIFF
--- a/tuningfork.pro
+++ b/tuningfork.pro
@@ -335,7 +335,7 @@ endif else centre=centre_orig
 cdelt=abs(sxpar(starmaphdr,'CDELT1'))
 pixtopc=distance*!dtor*cdelt/sqrt(cos(inclination)) ;pixel size in pc -- assumes small angles, i.e. tan(x)~x
 if sqrt(2.)*pixtopc gt apertures(naperture-2) then begin
-    print, ' error: less than 3 aperture sizes larger than pixel diagonal'
+    print, ' error: less than 2 aperture sizes exceed inclination-corrected pixel diagonal'
     print, ' quitting...'
     stop
 endif


### PR DESCRIPTION
Previously, a stop was triggered if the minimum aperture size was smaller than the pixel size (e.g. due to inclination). In the current version of the code (which allows the minimum aperture size to increase if needed), this no longer makes sense. A warning has been added, together with an increase of the minimum aperture size, and the stop is restricted to cases where less than 2 aperture sizes exceed the inclination-corrected pixel diagonal. The use of diagonal rather than size implies the addition of a factor of sqrt(2).
