### PR TITLE
Fix astrometry_equal

### DIFF
--- a/astrometry_equal.pro
+++ b/astrometry_equal.pro
@@ -1,17 +1,19 @@
 ;----------------------------------------------------------------------------------------
-function astrometry_equal, imagea, hdra, imageb, hdrb, $ ; input parameters
-         astr=astr, strict_equinox=strict_equinox        ; keywords
+function astrometry_equal, imagea, hdra, imageb, hdrb, tolerance $  ; input parameters
+                                      , astr=astr, strict_equinox=strict_equinox ; keywords
 ;----------------------------------------------------------------------------------------
-; *** astrometry_equal checks if two astronomical images with associate fits headers have
-; *** the same astrometry. Returns 1 if true and 0 if false.
+; *** astrometry_equal checks if two 2D astronomical images with associated fits headers
+; *** have the same astrometry. Returns 1 if true and 0 if false.
 ;----------------------------------------------------------------------------------------
 ; *** To run, astrometry_equal  requires the:
 ; *** 1) The IDL Astronomy User's Library http://idlastro.gsfc.nasa.gov/
 ;--(input)-------------------------------------------------------------------------------
-; *** imagea : first image to be compared (array)
-; *** imageb : second image to be compared (array)
-; *** hdra   : fits header of first image (string array)
-; *** hdrb   : fits header of second image (string array)
+; *** imagea    : first image to be compared (array)
+; *** imageb    : second image to be compared (array)
+; *** hdra      : fits header of first image (string array)
+; *** hdrb      : fits header of second image (string array)
+; *** tolerance : allowable tolerance in decimal degrees between astrometric position of
+; ***             image pixels (e.g. 1.8" = 5e-4 decimal degrees)
 ;--(keywords)----------------------------------------------------------------------------
 ; *** astr          : (1/0) if set hdra and hdrb are taken to be astrometry structures
 ; ***               : as returned by the extast astrometry routine
@@ -26,8 +28,7 @@ function astrometry_equal, imagea, hdra, imageb, hdrb, $ ; input parameters
   compile_opt idl2 ; enforce strict array indexing, i.e. only use of [] and not () to index and use 32bit integers rather than 16bit as defaults
 
   ; 1) first a quick size check
-  if array_equal(size(imagea),size(imageb)) ne 1 then return, 0   ; check if each image has same size
-
+  if array_equal(size(imagea,/dimensions),size(imageb,/dimensions)) ne 1 then return, 0   ; check if each image has same size
 
   ; 2) now full check:
   if keyword_set(astr) then begin  ; hdrx keywords contain the astrometry structure and not the header
@@ -39,14 +40,32 @@ function astrometry_equal, imagea, hdra, imageb, hdrb, $ ; input parameters
     extast, hdrb, astrb
   endelse
 
+  ; 2a) get platescale:
+  getrot, astra, rota, cdelt_a
+  getrot, astrb, rotb, cdelt_b
 
+  ; if cdelt_a le 0.0d0 && cdelt_b le 0.0d0 && abs(cdelt_a-cdelt_b) gt tolerance then return, 0 ; check platescales of images are within tolerance
+  if  abs(cdelt_a[0]-cdelt_b[0]) gt tolerance then return, 0 ; check platescales of images are within tolerance
+  if  abs(cdelt_a[1]-cdelt_b[1]) gt tolerance then return, 0 ; check platescales of images are within tolerance
 
-  diff_list = compare_struct(astra,astrb)
-  if n_elements(diff_list) gt 0 then for ii=0,(n_elements(diff_list)-1),1 do begin
-    difference = diff_list[ii]
-    if difference.field ne '.DATEOBS' && difference.field ne '.MJDOBS' && difference.field ne '' then return, 0 ; allow observation date to be different, otherwise astrometry must be the same
-  endfor
+  ; 2b) compare co-ordinates of all pixels in images (brute-force approach)
 
-  return, 1 ; astrometry is equal
+  image_dims = size(imagea, /dimensions) ; have checked size in 1)
+
+  image_xdim = image_dims[0]
+  image_ydim = image_dims[1]
+
+  image_xcents = (fltarr(image_ydim)+1.0) ## (findgen(image_xdim) ) ; pixel centres in idl convention
+  image_ycents = (fltarr(image_xdim)+1.0) # (findgen(image_ydim) )  ; idl pixel (0,0) = .fits pixel (1,1) ; need to take account of this for idl astronomy routines that convert to idl pixels
+
+  xy2ad,image_xcents, image_ycents, astra, ra_a, dec_a ; get astrometric co-ordinates in degrees
+  xy2ad,image_xcents, image_ycents, astrb, ra_b, dec_b
+
+  ra_list = where( (abs(ra_a - ra_b) gt tolerance) eq 1, ra_count)
+  if ra_count gt 0 then return, 0
+  dec_list = where( (abs(dec_a - dec_b) gt tolerance) eq 1, dec_count)
+  if dec_count gt 0 then return, 0
+
+  return, 1 ; astrometry is sufficiently equal given the specified tolerance
 
 end

--- a/input_file
+++ b/input_file
@@ -85,6 +85,7 @@ maxradius       10000.    # Maximum radius for analysis in pc
 Fs1_Fs2_min     15.       # Minimum primary-to-secondary star formation tracer flux ratio for including pixels (only if use_star3=1)
 max_sample      10        # Maximum number of pixels per map resolution FWHM
 nbins           20        # Number of bins used during sensitivity limit calculation to sample the intensity PDFs and fit Gaussians
+astr_tolerance  2.5e-8    # allowable tolerance in decimal degrees between astrometric position of image pixels of different images (e.g. 0.9" = 2.5e-4 decimal degrees)
 # INPUT PARAMETERS 2 (apertures)
 lapmin          25.       # Minimum aperture size (i.e. diameter) in pc to create smoothened maps for
 lapmax          6400.     # Maximum aperture size (i.e. diameter) in pc to create smoothened maps for
@@ -129,5 +130,3 @@ kappa0         -4.61979   # Log of the Rosseland-mean opacity proportionality co
 #              END PARAMETER FILE              #
 #                                              #
 ################################################
-
-

--- a/tuningfork.pro
+++ b/tuningfork.pro
@@ -97,7 +97,7 @@ expected_flags4=['set_centre','tophat','loglevels','flux_weight','calc_ap_area',
 expected_flags=[expected_flags1,expected_flags2,expected_flags3,expected_flags4] ;variable names of expected flags (all)
 expected_filenames=['datadir','galaxy','starfile','starfile2','gasfile','gasfile2','starfile3'] ;variable names of expected filenames
 expected_masknames=['maskdir','star_ext_mask','star_int_mask','gas_ext_mask','gas_int_mask','star_ext_mask2','star_int_mask2','gas_ext_mask2','gas_int_mask2','star_ext_mask3','star_int_mask3'] ;variable names of expected mask filenames
-expected_params1=['distance','inclination','posangle','centrex','centrey','minradius','maxradius','Fs1_Fs2_min','max_sample','nbins'] ;variable names of expected input parameters (1)
+expected_params1=['distance','inclination','posangle','centrex','centrey','minradius','maxradius','Fs1_Fs2_min','max_sample','nbins','astr_tolerance'] ;variable names of expected input parameters (1)
 expected_params2=['lapmin','lapmax','naperture','peak_res','max_res'] ;variable names of expected input parameters (2)
 expected_params3=['npixmin','nsigma','logrange_s','logspacing_s','logrange_g','logspacing_g'] ;variable names of expected input parameters (3)
 expected_params4=['tstariso','tstariso_errmin','tstariso_errmax','tgasmini','tgasmaxi','tovermini'] ;variable names of expected input parameters (4)
@@ -373,10 +373,10 @@ tstariso_rerrmax=tstariso_errmax/tstariso ;Relative upward standard error on tst
 if regrid then begin
     print,' ==> syncronising masks of maps from '+griddir
     masksimple = 1 ; propogate masks using simple pixel by pixel comparison
-    if astrometry_equal(starmap, starmaphdr, gasmap, gasmaphdr) then begin ;check astrometry is equal
-        if use_star2 then if astrometry_equal(starmap, starmaphdr, starmap2, starmaphdr2) ne 1 then masksimple = 0
-        if use_star3 then if astrometry_equal(starmap, starmaphdr, starmap3, starmaphdr3) ne 1 then masksimple = 0
-        if use_gas2 then if astrometry_equal(starmap, starmaphdr, gasmap2, gasmaphdr2) ne 1 then masksimple = 0
+    if astrometry_equal(starmap, starmaphdr, gasmap, gasmaphdr, astr_tolerance) then begin ;check astrometry is equal
+        if use_star2 then if astrometry_equal(starmap, starmaphdr, starmap2, starmaphdr2, astr_tolerance) ne 1 then masksimple = 0
+        if use_star3 then if astrometry_equal(starmap, starmaphdr, starmap3, starmaphdr3, astr_tolerance) ne 1 then masksimple = 0
+        if use_gas2 then if astrometry_equal(starmap, starmaphdr, gasmap2, gasmaphdr2, astr_tolerance) ne 1 then masksimple = 0
     endif else masksimple = 0
 
     if masksimple then begin ;create array of total mask


### PR DESCRIPTION
 * add new input parameter to input_file (astr_tolerance). This is the
   allowable tolerance in decimal degrees between astrometric position
   of corresponding image pixels of different images
 * tuningfork.pro now reads in astr_tolerance and passes the value to
   each call of astrometry_equal
 * switch astrometry_equal to brute_force comparison of difference
   between world co-ordinates of each pixel for the two images being
   compared against a tolerance value in decimal degrees

Closes: #120