### PR TITLE
Final changes to make code consistent with Paper II after completing Section 3.

### DIFF
--- a/input_file
+++ b/input_file
@@ -112,7 +112,7 @@ tovermini       0.01      # Minimum value of tover considered during fitting pro
 nmc             1000      # Number of Monte-Carlo peak drawing experiments to be executed and averaged over during fitting process
 ndepth          4         # Maximum number of free parameter array refinement loops for obtaining best-fitting value
 ntry            101       # Size of each free parameter array to obtain the best-fitting value
-nphysmc         10000     # Number of Monte-Carlo experiments for error propagation of derived physical quantities
+nphysmc         100000    # Number of Monte-Carlo experiments for error propagation of derived physical quantities
 # INPUT PARAMETERS 6 (conversions and constants to calculate derived quantities)
 convstar       -3.69206   # Log of multiplication factor to convert the pixel value in starfile to a SFR in Msun/yr (if maptypes=1 or maptypes=3) or to a gas mass in Msun (if maptypes=2)
 convstar_rerr   0.        # Relative error (sigma_x/x) of convstar


### PR DESCRIPTION
derivephys.pro:
- decreased size of random number array to be nicer on RAM
- changed tstariso drawing to use symmetric Gaussian with sigma set by mean of asymmetric uncertainties

input_file:
- increase default number of Monte-Carlo error propagation draws from 10^5 to 10^6