### PR TITLE
Stop printing 'Stop encountered'

### DIFF
--- a/f_error.pro
+++ b/f_error.pro
@@ -4,7 +4,6 @@ pro f_error,estring
     nstring=n_elements(estring)
     estring(0)='error: '+estring(0)
     for i=0,nstring-1 do print,' '+estring(i)
-    print,' quitting...'
-    stop
+    stop, ' quitting...'
 end
 


### PR DESCRIPTION
Stops the unnecessary line:
`% Stop encountered: F_ERROR             8 /.../KL14/f_error.pro`
This addressing the second part of #150 

(Same as #152)