### PR TITLE
Update how expected errors are handeled

### DIFF
--- a/f_error.pro
+++ b/f_error.pro
@@ -2,9 +2,9 @@
 
 pro f_error,estring
     nstring=n_elements(estring)
-    estring(0)='error: '+estring(0)
-    for i=0,nstring-1 do print,' '+estring(i)
-    print,' quitting...'
-    stop
+    print, '; ---------- KL14 ERROR MESSAGE ----------'
+    for i=0,nstring-1 do print,'; ' + estring(i)
+    print, '; ---------- KL14 ERROR MESSAGE ----------'
+    MESSAGE, 'KL14 Error encountered', /NoName
 end
 


### PR DESCRIPTION
Produces some output like this:
```
; ---------- KL14 ERROR MESSAGE ----------
; insufficient number of peaks identified (2)
; ---------- KL14 ERROR MESSAGE ----------
% KL14 Error encountered
% Execution halted at: F_ERROR             8 /.../KL14/f_error.pro
%                      PEAKS2D            16 /.../KL14/peaks2d.pro
%                      $MAIN$            575 /.../KL14/tuningfork.pro
```